### PR TITLE
fix: desktop login, demo-host vercel ci, and dashboard 500/cors

### DIFF
--- a/.github/workflows/deploy-demo-host.yml
+++ b/.github/workflows/deploy-demo-host.yml
@@ -23,6 +23,11 @@ jobs:
           cache: npm
           cache-dependency-path: demo-host/package-lock.json
 
+      # vercel build runs `nuxt build` but does not reliably install deps in this
+      # sub-directory setup → install them ourselves so the nuxt binary is present.
+      - name: Install demo-host dependencies
+        run: npm ci
+
       - name: Deploy demo-host to Vercel
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -98,7 +98,10 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NUXT_PUBLIC_API_BASE: ${{ secrets.NUXT_PUBLIC_API_BASE }}
+          # Baked into the static desktop bundle. Must be non-empty: an empty env var
+          # overrides the nuxt.config fallback and ships apiBase="" (all API calls then
+          # resolve against http://tauri.localhost and return the SPA HTML, not the API).
+          NUXT_PUBLIC_API_BASE: ${{ secrets.NUXT_PUBLIC_API_BASE || 'https://api.devleadhunter.dibodev.fr' }}
           NUXT_PUBLIC_GITHUB_REPO: ${{ github.repository }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}

--- a/api/api/v1/routes/dashboard.py
+++ b/api/api/v1/routes/dashboard.py
@@ -1,4 +1,5 @@
 """Dashboard home KPIs aggregated for the current user."""
+import logging
 from datetime import date, datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, Query
@@ -22,6 +23,8 @@ from schemas.dashboard import (
 from services.auth_service import get_current_active_user
 from services.behavior_service import behavior_service
 from services.order_service import order_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
@@ -131,13 +134,18 @@ async def dashboard_hot_leads(
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db),
 ) -> HotLeadsResponse:
-    """Return the hottest leads (demo + email engagement) for the current user."""
-    leads = await behavior_service.get_hot_leads(db, current_user.id, limit=20)
-    return HotLeadsResponse(
-        items=[
+    """
+    Return the hottest leads (demo + email engagement) for the current user.
+
+    Behaviour aggregation depends on PostHog + DB reads; on any unexpected failure we
+    return an empty list so the dashboard widget degrades gracefully instead of 500.
+    """
+    try:
+        leads = await behavior_service.get_hot_leads(db, current_user.id, limit=20)
+        items = [
             HotLeadResponse(
                 prospect_id=lead["prospect_id"],
-                name=lead["name"],
+                name=lead.get("name") or "—",
                 city=lead.get("city"),
                 temperature=lead["temperature"],
                 score=lead["score"],
@@ -146,4 +154,7 @@ async def dashboard_hot_leads(
             )
             for lead in leads
         ]
-    )
+    except Exception:  # noqa: BLE001
+        logger.exception("hot-leads aggregation failed for user %s", current_user.id)
+        return HotLeadsResponse(items=[])
+    return HotLeadsResponse(items=items)

--- a/api/core/config.py
+++ b/api/core/config.py
@@ -370,6 +370,18 @@ class Settings(BaseSettings):
         """
         origins = self.cors_origins.copy()
 
+        # Tauri desktop app origins (constant across API environments). On Windows/WebView2
+        # the packaged app is served from http://tauri.localhost; macOS/Linux use tauri://localhost.
+        # Without these, the desktop login preflight is blocked by CORS.
+        desktop_origins = [
+            "http://tauri.localhost",
+            "https://tauri.localhost",
+            "tauri://localhost",
+        ]
+        for origin in desktop_origins:
+            if origin not in origins:
+                origins.append(origin)
+
         if self.env.lower() != "production":
             development_origins = [
                 "http://localhost:3000",

--- a/api/main.py
+++ b/api/main.py
@@ -79,6 +79,39 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """
+    Return a clean 500 that still carries CORS headers.
+
+    Starlette emits its default 500 above the CORS middleware, so the browser sees
+    "CORS header missing" instead of the real error. We log the exception and re-add
+    the CORS headers (based on the request Origin) so the frontend gets a proper error.
+
+    Args:
+        request: The incoming request that failed.
+        exc: The unhandled exception raised while processing the request.
+
+    Returns:
+        A JSON 500 response with CORS headers when the Origin is allowed.
+    """
+    logging.getLogger(__name__).exception(
+        "Unhandled error on %s %s", request.method, request.url.path
+    )
+    headers: dict = {}
+    origin = request.headers.get("origin")
+    if origin and origin in settings.allowed_cors_origins:
+        headers["Access-Control-Allow-Origin"] = origin
+        headers["Access-Control-Allow-Credentials"] = "true"
+        headers["Vary"] = "Origin"
+    return JSONResponse(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        content={"detail": "Internal server error"},
+        headers=headers,
+    )
+
+
 # Include API routes
 app.include_router(api_router, prefix=settings.api_prefix)
 


### PR DESCRIPTION
Corrige trois problèmes indépendants remontés après la sortie du logiciel.

## 1. Login desktop cassé (`fix(desktop)`)
Le build desktop embarquait `apiBase=""` → `login()` faisait `fetch('/api/v1/auth/login')` résolu contre `http://tauri.localhost` → renvoyait le HTML du SPA au lieu de l'API.
- **Cause** : le secret `NUXT_PUBLIC_API_BASE` est vide/absent, et une env var vide **écrase** le fallback du `nuxt.config` (gotcha Nuxt) → Nuxt bake `""`.
- **Fix** : `NUXT_PUBLIC_API_BASE: ${{ secrets.NUXT_PUBLIC_API_BASE || 'https://api.devleadhunter.dibodev.fr' }}` (valeur toujours non-vide au build).
- **Bonus** : ajout des origines Tauri (`http://tauri.localhost`, `https://tauri.localhost`, `tauri://localhost`) au CORS de l'API — sinon le preflight du login desktop serait bloqué même avec le bon apiBase.

## 2. CI `Deploy demo host to Vercel` qui crashe (`fix(ci)`)
`vercel build` lançait `nuxt build` mais les deps n'étaient jamais installées → `sh: 1: nuxt: not found` (exit 127). Ajout d'un `npm ci` avant le build (comme les autres workflows).

## 3. `GET /dashboard/hot-leads` → 500 + "CORS Missing Allow Origin" (`fix(api)`)
Le "CORS missing" était un **symptôme** : Starlette émet son 500 par défaut au-dessus du middleware CORS → pas de header CORS, donc le navigateur masque la vraie erreur.
- **Fix général** : handler d'exception global qui log l'erreur et **réajoute les headers CORS** sur les 500 (selon l'Origin) → le front reçoit une vraie erreur, plus un faux CORS.
- **Fix ciblé** : `hot-leads` dégrade gracieusement (liste vide) sur erreur d'agrégation au lieu de 500, et `name` est coercé (`or "—"`) — cause probable du 500 (prospect au nom `null` contre un champ `name: str` requis).

## Hors périmètre (non pushable ici)
Les erreurs de fonts en prod (`_fonts/*.woff2` → 500, `content-type: application/json`, transfert partiel) viennent du **nginx du VPS**, pas du repo (aucune `routeRules`/CSP côté code). Fix à appliquer côté serveur (mapping MIME woff2 + service statique de `/_fonts`). Détaillé dans le chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)