### PR TITLE
fix(ci): build demo-host with nitro vercel preset instead of vercel build

### DIFF
--- a/.github/workflows/deploy-demo-host.yml
+++ b/.github/workflows/deploy-demo-host.yml
@@ -23,8 +23,7 @@ jobs:
           cache: npm
           cache-dependency-path: demo-host/package-lock.json
 
-      # vercel build runs `nuxt build` but does not reliably install deps in this
-      # sub-directory setup → install them ourselves so the nuxt binary is present.
+      # Install deps so the local nuxt binary exists for the build step below.
       - name: Install demo-host dependencies
         run: npm ci
 
@@ -39,5 +38,8 @@ jobs:
         run: |
           npm i -g vercel@latest
           vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
-          vercel build --prod --token="$VERCEL_TOKEN"
+          # `vercel build` runs `nuxt build` without node_modules/.bin on PATH → "nuxt: not found".
+          # Build ourselves via npm (resolves the local nuxt) with Nitro's Vercel preset, which
+          # emits the .vercel/output Build Output API that `vercel deploy --prebuilt` consumes.
+          NITRO_PRESET=vercel npm run build
           vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ lerna-debug.log*
 .nitro/
 .cache/
 dist/
+.vercel/
 
 # TypeScript
 *.tsbuildinfo


### PR DESCRIPTION
Suite du fix précédent : la CI `Deploy demo host to Vercel` échouait encore avec `sh: 1: nuxt: not found` / `Command "nuxt build" exited with 127`.

## Diagnostic (confirmé sur les logs du run)
- L'étape `npm ci` s'exécute bien (627 packages, `nuxt prepare` OK) → `demo-host/node_modules/.bin/nuxt` existe.
- Mais `vercel build` lance `nuxt build` dans un shell **sans `./node_modules/.bin` dans le PATH** → binaire introuvable. Et `vercel build` ne lance **jamais** son propre `npm install` dans ce setup en sous-dossier.
- Ce workflow n'avait en fait **jamais réussi** (échecs depuis le 5 juin).

## Fix
On retire le composant fautif (`vercel build`) et on build nous-mêmes :
```
NITRO_PRESET=vercel npm run build     # npm résout le nuxt local ; preset Vercel → .vercel/output
vercel deploy --prebuilt --prod       # déploie le Build Output API
```

**Vérifié en local** : `NITRO_PRESET=vercel npm run build` produit un `.vercel/output` conforme (Build Output API **v3** : `config.json` + `functions/` + `static/`), et Nitro affiche lui-même *« You can deploy this build using `npx vercel deploy --prebuilt` »*.

- `+ .vercel/` ajouté au `.gitignore` (l'output de build ne doit pas être versionné).

## Après merge
Le workflow ne se déclenche que sur push `main` → merger cette PR relancera le déploiement. Je peux surveiller le run si tu veux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)