### PR TITLE
fix(web): disable self-hosted fonts, load inter from cdn

### DIFF
--- a/web/nuxt.config.ts
+++ b/web/nuxt.config.ts
@@ -90,6 +90,11 @@ export default defineNuxtConfig({
   },
 
   ui: {
+    // Disable @nuxt/ui's bundled @nuxt/fonts self-hosting. On the OVH/nginx host the
+    // self-hosted /_fonts/*.woff2 are served with the wrong MIME type (application/json)
+    // and, with nosniff, the browser aborts the download. Inter is loaded from the Google
+    // Fonts CDN <link> in app.head instead, which serves the correct font/woff2 MIME.
+    fonts: false,
     theme: {
       colors: ['primary', 'neutral', 'success', 'info', 'warning', 'error'],
     },


### PR DESCRIPTION
Corrige les erreurs console en prod :
`downloadable font: download failed ... /_fonts/…woff2 (status=2152398924)`.

## Cause
`@nuxt/ui` (v4.8) embarque `@nuxt/fonts`, qui **self-host** Inter sous `/_fonts/*.woff2`. Sur l'hôte OVH/nginx ces fichiers sont servis avec un **mauvais type MIME** (`application/json`) ; combiné à `X-Content-Type-Options: nosniff`, le navigateur **avorte** le téléchargement (`NS_ERROR_NET_PARTIAL_TRANSFER`). Inter était de toute façon déjà chargé en double via le `<link>` Google Fonts CDN dans `app.head`.

## Fix
`ui: { fonts: false }` désactive l'intégration `@nuxt/fonts` (option officielle `@nuxt/ui` : *"Enable or disable @nuxt/fonts module"*). Plus aucune requête `/_fonts/` ; Inter est servi par le CDN Google Fonts (bon MIME `font/woff2`).

## Vérifié en local (build prod `NITRO_PRESET=node-server`)
- `refs to /_fonts/ in .output` → **0**
- dossier `.output/public/_fonts` → **absent**
- `<link>` CDN Inter → **toujours baké** dans le rendu serveur

Aucun changement visuel : la police reste Inter (via CDN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)